### PR TITLE
Remove demands (Go, Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,6 @@ steps:
       filename: 'YOUR_K6_TEST_SCRIPT.js'
 ```
 
-> ### ⚠️ Custom build agents
->
-> To be able to run the k6 extension on a custom build agent, you need to
-> have both `python` and `go` installed.
-
 ## Inputs
 
 These options are also available from the settings dialog in the pipelines editor.

--- a/src/task.json
+++ b/src/task.json
@@ -21,10 +21,6 @@
     "DeploymentGroup"
   ],
   "instanceNameFormat": "Run $(filename) with k6",
-  "demands": [
-    "Go",
-    "Python"
-  ],
   "inputs": [
     {
       "name": "cloud",


### PR DESCRIPTION
- `Go`
  No longer needed since extension doesn't build k6 from source anymore.
- `Python`
  Not sure why it was specified in the first place.
  Even initial commit doesn't contain any Python references.